### PR TITLE
Add a changelog page auto generated from GitHub release notes

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,6 +16,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SPHINX_GITHUB_CHANGELOG_TOKEN: ${{ secrets.SPHINX_GITHUB_CHANGELOG_TOKEN }}
     steps:
       - uses: actions/checkout@v4
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,6 +45,7 @@ launch_buttons:
 sphinx:
   extra_extensions:
     - nbsphinx
+    - sphinx_github_changelog
     - sphinx.ext.autodoc
     - sphinx.ext.intersphinx
     - sphinx.ext.mathjax

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -18,3 +18,4 @@ parts:
   - caption: References
     chapters:
       - file: Docstrings.rst
+      - file: changelog.md

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,10 @@
+# What's New
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Intended Effort Versioning](https://jacobtomlinson.dev/effver/) (EffVer for short).
+Release notes are automatically recovered from GitHub by [sphinx-github-changelog](https://github.com/ewjoachim/sphinx-github-changelog).
+
+```{changelog}
+:changelog-url: https://docs.fschuch.com/xcompact3d_toolbox/changelog.html
+:github: https://github.com/fschuch/xcompact3d_toolbox/releases/
+:pypi: https://pypi.org/project/xcompact3d-toolbox/
+```

--- a/docs/examples/Square.ipynb
+++ b/docs/examples/Square.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "<div class=\"alert alert-info\">\n",
     "\n",
-    "The no-flux boundary condition for the scalar field(s) at the slid/fluid interface is experimental, and it is still not available at XCompact3d's main repository.\n",
+    "The no-flux boundary condition for the scalar field(s) at the solid/fluid interface is experimental, and it is still not available at XCompact3d's main repository.\n",
     "\n",
     "</div>"
    ]

--- a/docs/tutorial/computing_and_plotting.ipynb
+++ b/docs/tutorial/computing_and_plotting.ipynb
@@ -171,7 +171,7 @@
    "outputs": [],
    "source": [
     "for var in [\"u\", \"pp\"]:\n",
-    "    dataset[var] = dataset[var].where(dataset.epsi == 0.0, np.NaN)"
+    "    dataset[var] = dataset[var].where(dataset.epsi == 0, np.nan)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ visu = [
 
 [project.urls]
 Repository = "https://github.com/fschuch/xcompact3d_toolbox"
-Changelog = "https://github.com/fschuch/xcompact3d_toolbox/releases"
+Changelog = "https://docs.fschuch.com/xcompact3d_toolbox/changelog.html"
 Documentation = "https://docs.fschuch.com/xcompact3d_toolbox"
 Issues = "https://github.com/fschuch/xcompact3d_toolbox/issues"
 
@@ -164,12 +164,14 @@ dependencies = [
     "pooch==1.8.1",
     "sphinx-autobuild==2024.4.16",
     "sphinx==7.3.7",
+    "sphinx-github-changelog==1.3.0",
 ]
 
 [tool.hatch.envs.docs.scripts]
 config = "jupyter-book config sphinx docs {args}"
 build = ["config", "jupyter-book build docs --path-output build {args}"]
 serve = ["config", "sphinx-autobuild docs build/_build/html --ignore='**/data/*' --watch xcompact3d_toolbox --open-browser {args}"]
+clear = "rm -rf build/_build"
 
 [tool.hatch.envs.hatch-static-analysis]
 config-path = "ruff_defaults.toml"

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,0 @@
-# See pyproject.toml
-
-# Reference: https://github.com/dependabot/dependabot-core/issues/6593
-
-# This file is included to help dependabot determine we are using pip-tools to create requirements files.
-# In reality, the dependencies for this project are in pyproject.toml

--- a/xcompact3d_toolbox/io.py
+++ b/xcompact3d_toolbox/io.py
@@ -570,6 +570,9 @@ class Dataset(traitlets.HasTraits):
 
         >>> ux = prm.dataset.load_array("ux-000.bin")
 
+        .. versionchanged:: 1.2.0
+            The argument ``add_time`` changed to keyword-only.
+
         """
 
         coords = self._mesh.drop(*self.drop_coords)
@@ -915,8 +918,8 @@ class Dataset(traitlets.HasTraits):
         ... )
 
         * From a dataset, write only the variables with the attribute ``file_name``,
-            notice that ``ux`` and ``uy`` will not be overwritten because them do not
-            have the attribute ``file_name``:
+          notice that ``ux`` and ``uy`` will not be overwritten because them do not
+          have the attribute ``file_name``:
 
             >>> for ds in prm.dataset:
             ...     ds["vort"] = ds.uy.x3d.first_derivative("x") - ds.ux.x3d.first_derivative(
@@ -927,16 +930,16 @@ class Dataset(traitlets.HasTraits):
 
         * Write an array:
 
-            >>> for ds in prm.dataset:
-            ...     vort = ds.uy.x3d.first_derivative("x") - ds.ux.x3d.first_derivative("y")
-            ...     vort.attrs["file_name"] = "vorticity"
-            ...     prm.dataset.write(vort)
+          >>> for ds in prm.dataset:
+          ...     vort = ds.uy.x3d.first_derivative("x") - ds.ux.x3d.first_derivative("y")
+          ...     vort.attrs["file_name"] = "vorticity"
+          ...     prm.dataset.write(vort)
 
-            or
+          or
 
-            >>> for ds in prm.dataset:
-            ...     vort = ds.uy.x3d.first_derivative("x") - ds.ux.x3d.first_derivative("y")
-            ...     prm.dataset.write(data=vort, file_prefix="vorticity")
+          >>> for ds in prm.dataset:
+          ...     vort = ds.uy.x3d.first_derivative("x") - ds.ux.x3d.first_derivative("y")
+          ...     prm.dataset.write(data=vort, file_prefix="vorticity")
 
         .. note :: It is not recommended to load the arrays with
             ``add_time = False`` when planning to write the results in a
@@ -1044,6 +1047,9 @@ class Dataset(traitlets.HasTraits):
         can be visualized on any external tool:
 
         >>> prm.dataset.write_xdmf()
+
+        .. versionchanged:: 1.2.0
+            Added argument ``float_precision``.
         """
         if self.set_of_variables:
             time_numbers = list(range(len(self)))

--- a/xcompact3d_toolbox/mesh.py
+++ b/xcompact3d_toolbox/mesh.py
@@ -11,28 +11,14 @@ from math import isclose
 
 import numpy as np
 import traitlets
+from deprecated.sphinx import versionadded
 
 from xcompact3d_toolbox.param import param
 
 
+@versionadded(version="1.2.0")
 class Istret(IntEnum):
-    """Mesh refinement type.
-
-    Parameters
-    ----------
-    value : int
-        Type of mesh refinement:
-
-            * 0 - No refinement;
-            * 1 - Refinement at the center;
-            * 2 - Both sides;
-            * 3 - Just near the bottom.
-
-    Returns
-    -------
-    :obj:`xcompact3d_toolbox.mesh.Istret`
-        Mesh refinement type
-    """
+    """Mesh refinement type."""
 
     NO_REFINEMENT = 0
     CENTER_REFINEMENT = 1
@@ -355,12 +341,8 @@ class StretchedCoordinate(Coordinate):
         Stretched coordinate
     """
 
-    istret = traitlets.UseEnum(
-        Istret,
-        default_value=0,
-        help="type of mesh refinement (0:no, 1:center, 2:both sides, 3:bottom)",
-    )
-    beta = traitlets.Float(default_value=1.0, min=0.0, help="Refinement parameter")
+    istret = traitlets.UseEnum(Istret, default_value=0)
+    beta = traitlets.Float(default_value=1.0, min=0.0)
 
     def __repr__(self):
         if self.istret == 0:

--- a/xcompact3d_toolbox/parameters.py
+++ b/xcompact3d_toolbox/parameters.py
@@ -893,6 +893,9 @@ class Parameters(
         .. _#7:
             https://github.com/fschuch/xcompact3d_toolbox/issues/7
 
+        .. versionchanged:: 1.2.0
+            The argument ``raise_warning`` changed to keyword-only.
+
         """
 
         super().__init__()
@@ -1146,6 +1149,8 @@ class Parameters(
         ...     p_col=2,
         ... )
 
+        .. versionchanged:: 1.2.0
+            The argument ``raise_warning`` changed to keyword-only.
         """
         # They are high priority in order to avoid errors with validations and observations
         for bc in "nclx1 nclxn ncly1 nclyn nclz1 nclzn numscalar ilesmod".split():

--- a/xcompact3d_toolbox/sandbox.py
+++ b/xcompact3d_toolbox/sandbox.py
@@ -77,6 +77,8 @@ def init_epsi(prm: Parameters, *, dask: bool = False) -> dict[str, xr.DataArray]
     >>> prm = xcompact3d_toolbox.Parameters()
     >>> epsi = xcompact3d_toolbox.init_epsi(prm)
 
+    .. versionchanged:: 1.2.0
+        The argument ``dask`` changed to keyword-only.
     """
 
     epsi: dict[str, xr.DataArray] = {}
@@ -404,6 +406,8 @@ class Geometry:
         .. _`numpy-stl's documentation`: https://numpy-stl.readthedocs.io/en/latest/
         .. _`Numba`: http://numba.pydata.org/
 
+        .. versionchanged:: 1.2.0
+            All arguments changed to keyword-only.
         """
 
         def get_boundary(mesh_coord, coord):
@@ -503,6 +507,8 @@ class Geometry:
         >>> for key in epsi.keys():
         >>>     epsi[key] = epsi[key].geo.cylinder(x=4.0, y=5.0)
 
+        .. versionchanged:: 1.2.0
+            All arguments changed to keyword-only.
         """
 
         for key in kwargs:
@@ -554,6 +560,8 @@ class Geometry:
         >>> for key in epsi.keys():
         >>>     epsi[key] = epsi[key].geo.box(x=(2,5), y=(0,1))
 
+        .. versionchanged:: 1.2.0
+            All arguments changed to keyword-only.
         """
 
         for key in kwargs:
@@ -601,6 +609,8 @@ class Geometry:
         >>> for key in epsi.keys():
         >>>     epsi[key] = epsi[key].geo.square(x=5, y=2, z=1)
 
+        .. versionchanged:: 1.2.0
+            All arguments changed to keyword-only.
         """
         for key in kwargs:
             if key not in self._data_array.dims:
@@ -656,6 +666,8 @@ class Geometry:
         >>> for key in epsi.keys():
         >>>     epsi[key] = epsi[key].geo.sphere(x=1, y=1, z=1)
 
+        .. versionchanged:: 1.2.0
+            All arguments changed to keyword-only.
         """
         for key in kwargs:
             if key not in self._data_array.dims:
@@ -707,6 +719,8 @@ class Geometry:
         >>> for key in epsi.keys():
         >>>     epsi[key] = epsi[key].geo.ahmed_body(x=2)
 
+        .. versionchanged:: 1.2.0
+            All arguments changed to keyword-only.
         """
 
         import math


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a structured changelog accessible under the "References" section in the documentation.
  - Introduced the `sphinx_github_changelog` extension for automated release note retrieval.

- **Bug Fixes**
  - Corrected a typo in the `Square.ipynb` example notebook.

- **Improvements**
  - Updated documentation and code consistency across various modules.
  - Enhanced the tutorial notebook for better accuracy and clarity.
  - Updated the `Changelog` URL in `pyproject.toml`.

- **Refactor**
  - Converted several function arguments to keyword-only for improved clarity and usage consistency in `xcompact3d_toolbox`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->