### PR TITLE
Add support for Python 3.14 and drop 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -81,7 +81,7 @@ jobs:
           args: >
             -Dsonar.organization=fschuch
             -Dsonar.projectKey=fschuch_xcompact3d_toolbox
-            -Dsonar.python.version=3.9,3.10,3.11,3.12,3.13
+            -Dsonar.python.version=3.10,3.11,3.12,3.13,3.14
             -Dsonar.sources=src/xcompact3d_toolbox
             -Dsonar.tests=tests
             -Dsonar.python.coverage.reportPaths=coverage.*.xml

--- a/docs/references/how-to-contribute.md
+++ b/docs/references/how-to-contribute.md
@@ -15,7 +15,7 @@ and deploys the project to [PyPI](https://pypi.org).
 See [Why Hatch?](https://hatch.pypa.io/latest/why/) for more details.
 Refer to [Install Hatch](https://hatch.pypa.io/latest/install/) for instructions on how to install it on your operating system.
 
-Ensure you have Python 3.9 or later installed (this can also be done by hatch, take a look at `hatch python --help`).
+Ensure you have Python 3.10 or later installed (this can also be done by hatch, take a look at `hatch python --help`).
 
 ````{tip}
 Optionally, configure Hatch to keep virtual environments within the project folder:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "xcompact3d_toolbox"
 description = "A set of tools for pre and postprocessing prepared for the high-order Navier-Stokes solver XCompact3d"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "Felipe N. Schuch", email = "me@fschuch.com" }]
 license = "MIT"
 license-files = ["LICENSE"]
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python",
     "Topic :: Scientific/Engineering",
 ]
@@ -173,7 +173,7 @@ features = ["tests", "tests-extra"]
 extended = "test -n auto --reruns 7 --reruns-delay 1 {args}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
+python = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
 [tool.hatch.envs.docs]
 description = "Documentation environment"

--- a/src/xcompact3d_toolbox/genepsi.py
+++ b/src/xcompact3d_toolbox/genepsi.py
@@ -247,7 +247,7 @@ def gene_epsi_3d(epsi_in_dict, prm):
 
     ds = epsi.to_dataset(name="epsi")
 
-    for direction, ep in zip(["x", "y", "z"], [xepsi, yepsi, zepsi], strict=False):
+    for direction, ep in zip(["x", "y", "z"], [xepsi, yepsi, zepsi], strict=True):
         ds[f"nobj_{direction}"] = obj_count(epsi, direction)
         ds[f"nobjmax_{direction}"] = ds[f"nobj_{direction}"].max()
         ds[f"nobjraf_{direction}"] = obj_count(ep, direction)
@@ -267,7 +267,7 @@ def gene_epsi_3d(epsi_in_dict, prm):
     max_obj = np.max([ds.nobjmax_x.values, ds.nobjmax_y.values, ds.nobjmax_z.values])
     ds = ds.assign_coords(obj=range(max_obj), obj_aux=range(-1, max_obj))
 
-    for direction, ep, length in zip(["x", "y", "z"], [xepsi, yepsi, zepsi], [prm.xlx, prm.yly, prm.zlz], strict=False):
+    for direction, ep, length in zip(["x", "y", "z"], [xepsi, yepsi, zepsi], [prm.xlx, prm.yly, prm.zlz], strict=True):
         ds[f"xi_{direction}"], ds[f"xf_{direction}"] = get_boundaries(ep, direction, max_obj, length)
 
         if ds[f"ibug_{direction}"] != 0:
@@ -302,14 +302,14 @@ def write_geomcomplex(prm, ds) -> None:
         _array1 = transpose_n_flatten(array1)
         _array2 = transpose_n_flatten(array2)
         with open(os.path.join(data_path, f"n{dim}ifpif.dat"), "w", newline="\n") as file:
-            for value1, value2 in zip(_array1, _array2, strict=False):
+            for value1, value2 in zip(_array1, _array2, strict=True):
                 file.write(f"{value1:12d}{value2:12d}\n")
 
     def write_xixf(array1, array2, dim) -> None:
         _array1 = transpose_n_flatten(array1)
         _array2 = transpose_n_flatten(array2)
         with open(os.path.join(data_path, f"{dim}i{dim}f.dat"), "w", newline="\n") as file:
-            for value1, value2 in zip(_array1, _array2, strict=False):
+            for value1, value2 in zip(_array1, _array2, strict=True):
                 file.write(f"{value1:24.16E}{value2:24.16E}\n")
 
     def transpose_n_flatten(array):

--- a/src/xcompact3d_toolbox/genepsi.py
+++ b/src/xcompact3d_toolbox/genepsi.py
@@ -247,7 +247,7 @@ def gene_epsi_3d(epsi_in_dict, prm):
 
     ds = epsi.to_dataset(name="epsi")
 
-    for direction, ep in zip(["x", "y", "z"], [xepsi, yepsi, zepsi]):
+    for direction, ep in zip(["x", "y", "z"], [xepsi, yepsi, zepsi], strict=False):
         ds[f"nobj_{direction}"] = obj_count(epsi, direction)
         ds[f"nobjmax_{direction}"] = ds[f"nobj_{direction}"].max()
         ds[f"nobjraf_{direction}"] = obj_count(ep, direction)
@@ -267,7 +267,7 @@ def gene_epsi_3d(epsi_in_dict, prm):
     max_obj = np.max([ds.nobjmax_x.values, ds.nobjmax_y.values, ds.nobjmax_z.values])
     ds = ds.assign_coords(obj=range(max_obj), obj_aux=range(-1, max_obj))
 
-    for direction, ep, length in zip(["x", "y", "z"], [xepsi, yepsi, zepsi], [prm.xlx, prm.yly, prm.zlz]):
+    for direction, ep, length in zip(["x", "y", "z"], [xepsi, yepsi, zepsi], [prm.xlx, prm.yly, prm.zlz], strict=False):
         ds[f"xi_{direction}"], ds[f"xf_{direction}"] = get_boundaries(ep, direction, max_obj, length)
 
         if ds[f"ibug_{direction}"] != 0:
@@ -302,14 +302,14 @@ def write_geomcomplex(prm, ds) -> None:
         _array1 = transpose_n_flatten(array1)
         _array2 = transpose_n_flatten(array2)
         with open(os.path.join(data_path, f"n{dim}ifpif.dat"), "w", newline="\n") as file:
-            for value1, value2 in zip(_array1, _array2):
+            for value1, value2 in zip(_array1, _array2, strict=False):
                 file.write(f"{value1:12d}{value2:12d}\n")
 
     def write_xixf(array1, array2, dim) -> None:
         _array1 = transpose_n_flatten(array1)
         _array2 = transpose_n_flatten(array2)
         with open(os.path.join(data_path, f"{dim}i{dim}f.dat"), "w", newline="\n") as file:
-            for value1, value2 in zip(_array1, _array2):
+            for value1, value2 in zip(_array1, _array2, strict=False):
                 file.write(f"{value1:24.16E}{value2:24.16E}\n")
 
     def transpose_n_flatten(array):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of mismatched data lengths during geometry and output generation, helping avoid unexpected errors in some cases.

* **Chores**
  * Updated supported Python versions to require Python 3.10 or later.
  * Added Python 3.14 support and removed Python 3.9 from testing and CI checks.
  * Kept contributor documentation in sync with the updated Python requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->